### PR TITLE
fix: forward refs when using the `withToast` HOC and export `ToastCon…

### DIFF
--- a/src/components/Toast/ToastProvider.jsx
+++ b/src/components/Toast/ToastProvider.jsx
@@ -6,13 +6,17 @@ import getTheme from '../../theme/getTheme';
 import ToastQueue from '../../js/ToastQueue';
 import AnimatedList from '../AnimatedList/AnimatedList';
 
-const ToastContext = React.createContext();
+export const ToastContext = React.createContext();
 
-export const withToast = Component => props => (
-    <ToastContext.Consumer>
-        {context => <Component {...props} {...context} />}
-    </ToastContext.Consumer>
-);
+export const withToast = Component => {
+    const WithToast = React.forwardRef((props, ref) => (
+        <ToastContext.Consumer>
+            {context => <Component {...props} {...context} ref={ref} />}
+        </ToastContext.Consumer>
+    ));
+    WithToast.displayName = `WithToast(${Component.diplayName || Component.name || 'Component'})`;
+    return WithToast;
+};
 
 class ToastProviderClass extends React.Component {
     constructor(props) {

--- a/src/components/Toast/__tests__/ToastProvider.test.js
+++ b/src/components/Toast/__tests__/ToastProvider.test.js
@@ -42,6 +42,28 @@ describe('<ToastProvider>', () => {
         expect(toastQueue.enqueue).toHaveBeenCalledWith('toast', 'options');
     });
 
+    it('forwards refs with withToast', () => {
+        const Component = React.forwardRef((props, ref) => <div ref={ref} id="toast-component" />);
+        const HOC = withToast(Component);
+
+        const ref = React.createRef();
+        TestRenderer.create(
+            <ToastProvider>
+                <HOC ref={ref} />
+            </ToastProvider>,
+            {
+                createNodeMock: el => {
+                    if (el.props.id === 'toast-component') {
+                        return 'toast-component-ref';
+                    }
+                    return 'other-ref';
+                },
+            }
+        );
+
+        expect(ref.current).toBe('toast-component-ref');
+    });
+
     it('passes optionsFn to enqueue', () => {
         const optionsFn = jest.fn();
         const Component = () => <div id="toast-component" />;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@ export { default as Button } from './components/Button/Button';
 export { default as CloseButton } from './components/CloseButton/CloseButton';
 export { default as MediaObject } from './components/MediaObject/MediaObject';
 export { default as Toast } from './components/Toast/Toast';
-export { default as ToastProvider, withToast } from './components/Toast/ToastProvider';
+export {
+    default as ToastProvider,
+    ToastContext,
+    withToast,
+} from './components/Toast/ToastProvider';
 export { default as withNamespace } from './theme/withNamespace';
 export { default as getTheme } from './theme/getTheme';


### PR DESCRIPTION
…text`