### PR TITLE
styled-token: allow access to all values when using array path syntax, and add new object path syntax

### DIFF
--- a/packages/styled-token/README.md
+++ b/packages/styled-token/README.md
@@ -100,18 +100,18 @@ Since we are returning an interpolation and not a value, there are a few [caveat
 
 #### Arguments
 
-1. `path` (`string`|`array`): A string path to the token value, or an array of paths where the first defined token value from the list will be used.
+1. `path` (`string`|`array`|`object`): A string path to the token value, an array of paths, or an object of keyed paths. See below for [string](#examples-string-syntax), [array](#examples-array-syntax), and [object](#examples-object-syntax) syntax examples.
 2. `options` (`object`): Options for the token helper.
     * `options.namespace` (`string`): The namespace to pull the value from. This will override any namespace defined on the theme.
     * `options.defaultValue` (`any`): A fallback value that will be used if the `path` is not defined.
 
-3. `callback` (`function`): A callback that will be called with the token value.
+3. `callback` (`function`): A callback that will be called with the token value(s).
 
 #### Returns
 
 `Interpolation`: A styled-components [`TaggedTemplateLiteral`](https://styled-components.com/docs/api#taggedtemplateliteral) interpolation.
 
-#### Examples
+#### Examples: String Syntax
 
 ```js static
 // Access nested object properties with ".", or arrays with "[]"
@@ -122,9 +122,9 @@ const Link = styled.a`
 ```
 
 ```js static
-// Use "colors.brand" if it is defined, otherwise use "colors.blue"
-const Link = styled.a`
-    color: ${token(['colors.brand', 'colors.blue'])};
+// Modify the token value after it is retrieved
+const Button = styled.button`
+    padding: ${token('space.lg', t => t * 2)}px;
 `;
 ```
 
@@ -143,17 +143,39 @@ const Link = styled.a`
 ```
 
 ```js static
-// Modify the token value after it is retrieved
-const Button = styled.button`
-    padding: ${token('space.lg', t => t * 2)}px;
-`;
-```
-
-```js static
 // Pull the "space.lg" token from the "condensed" namespace, using "24" if it is not defined,
 // and then multiplying the result by two
 const Button = styled.button`
     padding: ${token('space.lg', { namespace: 'condensed', defaultValue: 24 }, t => t * 2)}px;
+`;
+```
+
+#### Examples: Array Syntax
+
+```js static
+// Use "colors.brand" if it is defined, otherwise use "colors.blue"
+const Link = styled.a`
+    color: ${token(['colors.brand', 'colors.blue'])};
+`;
+```
+
+```js static
+// Pull multiple values from the theme using an array
+const Button = styled.button`
+    padding: ${token(['space.lg', 'space.suffix'], (val, values) => `${values[0] * 2}${values[1]}`)};
+`;
+```
+
+#### Examples: Object Syntax
+
+```js static
+// Pull multiple values from the theme using an object (with fallback border colors)
+const Button = styled.button`
+    border: ${token({
+        borderColor: ['colors.brand', 'colors.blue'],
+        borderWidth: 'button.borderWidth',
+        borderStyle: 'button.borderStyle'
+    }, ({ borderColor, borderWidth, borderStyle }) => `${borderWidth} ${borderStyle} ${borderColor}`)};
 `;
 ```
 

--- a/packages/styled-token/src/__tests__/index.test.js
+++ b/packages/styled-token/src/__tests__/index.test.js
@@ -96,6 +96,19 @@ describe('token', () => {
         expect(token('foo["bar.baz"]')(props)).toBe('BARBAZ');
     });
 
+    it('tries to pull a property when the object key is an empty string', () => {
+        const props = {
+            theme: {
+                foo: {
+                    '': {
+                        bar: 'emptybar',
+                    },
+                },
+            },
+        };
+        expect(token('foo[""].bar')(props)).toBe('emptybar');
+    });
+
     it('throws an error with an unsupported path type', () => {
         const props = {};
         expect(() => {

--- a/packages/styled-token/src/__tests__/stringToPath.test.js
+++ b/packages/styled-token/src/__tests__/stringToPath.test.js
@@ -20,4 +20,8 @@ describe('stringToPath', () => {
     it('parses array access to object with a period in the property', () => {
         expect(stringToPath(`foo['bar.baz'].bat`)).toStrictEqual(['foo', 'bar.baz', 'bat']);
     });
+
+    it('parses an empty string key', () => {
+        expect(stringToPath(`foo[''].bat`)).toStrictEqual(['foo', '', 'bat']);
+    });
 });

--- a/packages/styled-token/src/index.js
+++ b/packages/styled-token/src/index.js
@@ -23,10 +23,7 @@ const getValues = (path, theme) => {
         const properties = stringToPath(p);
         for (let j = 0; j < properties.length && typeof currentValue !== 'undefined'; j += 1) {
             const property = properties[j];
-            // Skip empty string properties
-            if (property) {
-                currentValue = currentValue[property];
-            }
+            currentValue = currentValue[property];
         }
 
         // Set outer value to the first defined value

--- a/packages/styled-token/src/index.js
+++ b/packages/styled-token/src/index.js
@@ -1,10 +1,53 @@
 import { stringToPath } from './stringToPath';
 
 /**
- * See README.md for full documentation.
+ * Helper function for getting the value for a path or a fallback array.
  *
  * @method
  * @param path {string|array}
+ * @param theme {object} The theme namespace.
+ * @return {object} The derived value and an array of all values.
+ */
+const getValues = (path, theme) => {
+    let paths = path;
+    if (typeof path === 'string') {
+        paths = [path];
+    }
+
+    // Translate the array of paths to an array of values
+    let value;
+    const values = paths.map(p => {
+        let currentValue = theme;
+
+        // Traverse the path
+        const properties = stringToPath(p);
+        for (let j = 0; j < properties.length && typeof currentValue !== 'undefined'; j += 1) {
+            const property = properties[j];
+            // Skip empty string properties
+            if (property) {
+                currentValue = currentValue[property];
+            }
+        }
+
+        // Set outer value to the first defined value
+        if (typeof value === 'undefined') {
+            value = currentValue;
+        }
+
+        return currentValue;
+    });
+
+    return {
+        value,
+        values,
+    };
+};
+
+/**
+ * See README.md for full documentation.
+ *
+ * @method
+ * @param path {string|array|object}
  * @param [options] {object}
  * @param [callback] {function}
  * @return {function}
@@ -17,56 +60,53 @@ export default (path, options = {}, callback) => props => {
         options = {};
     }
 
-    let val = props.theme;
+    let { theme } = props;
 
     // Check for namespace
-    let namespace = props.theme && props.theme.NAMESPACE;
+    let namespace = theme && theme.NAMESPACE;
     if (typeof options.namespace === 'string') {
         // eslint-disable-next-line prefer-destructuring
         namespace = options.namespace;
     }
 
     // Move to namespace
-    if (val && namespace) {
-        val = val[namespace];
+    if (theme && namespace) {
+        theme = theme[namespace];
     }
 
-    let paths = path;
-    if (typeof paths !== 'object') {
-        paths = [path];
-    }
-
-    // Iterate through paths
-    const originalVal = val;
-    for (let i = 0; i < paths.length; i += 1) {
-        const p = paths[i];
-
-        // Reset val if we need to try another path
-        val = originalVal;
-
-        // Traverse the path
-        const properties = stringToPath(p);
-        for (let j = 0; j < properties.length && typeof val !== 'undefined'; j += 1) {
-            const property = properties[j];
-            // Skip empty string properties
-            if (property) {
-                val = val[property];
-            }
+    let value;
+    let values;
+    if (typeof path === 'string' || Array.isArray(path)) {
+        const results = getValues(path, theme);
+        // eslint-disable-next-line prefer-destructuring
+        value = results.value;
+        // eslint-disable-next-line prefer-destructuring
+        values = results.values;
+    } else if (typeof path === 'object') {
+        if (!callback) {
+            throw new Error('`callback` is required when `path` is an `object`');
         }
 
-        // Break out of paths array once we find the first defined value
-        if (typeof val !== 'undefined') {
-            break;
-        }
+        value = {};
+        Object.keys(path).forEach(key => {
+            const results = getValues(path[key], theme);
+            value[key] = results.value;
+        });
+    } else {
+        throw new Error('`path` should be one of `string`, `array`, `object`');
     }
 
     // defaultValue fallback
-    if (typeof val === 'undefined') {
-        val = options.defaultValue;
+    if (typeof value === 'undefined') {
+        value = options.defaultValue;
     }
 
     if (callback) {
-        return callback(val);
+        // Arrays gets both the derived value and the list of values as arguments
+        if (Array.isArray(path)) {
+            return callback(value, values);
+        }
+        return callback(value);
     }
-    return val;
+    return value;
 };


### PR DESCRIPTION
Sometimes you need to access multiple tokens at once -- this makes it possible without having to chain calls to the token helper.

![Screen Shot 2020-03-30 at 1 36 18 PM](https://user-images.githubusercontent.com/1432010/77959684-d9e67080-728b-11ea-8c6f-c6c5a75cb01f.png)
